### PR TITLE
added Better Title Case to transform multi-word variables. Example:

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,5 @@
 [
+  { "keys": ["ctrl+alt+c", "ctrl+alt+t"], "command": "convert_to_better_title"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+s"], "command": "convert_to_snake"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+shift+s"], "command": "convert_to_screaming_snake"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+c"], "command": "convert_to_camel"},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,5 @@
 [
+  { "keys": ["ctrl+alt+c", "ctrl+alt+t"], "command": "convert_to_better_title"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+s"], "command": "convert_to_snake"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+shift+s"], "command": "convert_to_screaming_snake"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+c"], "command": "convert_to_camel"},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,5 @@
 [
+  { "keys": ["ctrl+alt+c", "ctrl+alt+t"], "command": "convert_to_better_title"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+s"], "command": "convert_to_snake"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+shift+s"], "command": "convert_to_screaming_snake"},
   { "keys": ["ctrl+alt+c", "ctrl+alt+c"], "command": "convert_to_camel"},

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,5 +1,9 @@
 [
 	{
+	    "caption": "Convert Case: Better Title Case",
+	    "command": "convert_to_better_title"
+	},
+	{
 	    "caption": "Convert Case: PascalCase",
 	    "command": "convert_to_pascal"
 	},

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -7,6 +7,7 @@
 	        "id": "convert_case",
 	        "children":
 	        [
+                { "command": "convert_to_better_title", "caption": "Better Title Case" },
 	            { "command": "convert_to_snake", "caption": "snake_case" },
 	            { "command": "convert_to_screaming_snake", "caption": "SCREAMING_SNAKE_CASE" },
 	            { "command": "convert_to_camel", "caption": "camelCase" },

--- a/case_conversion.py
+++ b/case_conversion.py
@@ -16,6 +16,11 @@ else:
 SETTINGS_FILE = "CaseConversion.sublime-settings"
 
 
+def to_better_title(text, detectAcronyms, acronyms):
+    words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
+    return ' '.join(words)
+
+
 def to_snake_case(text, detectAcronyms, acronyms):
     words, case, sep = case_parse.parseVariable(text, detectAcronyms, acronyms)
     return '_'.join([w.lower() for w in words])
@@ -92,6 +97,11 @@ def run_on_selections(view, edit, func):
         new_text = leading + func(text.strip(), detectAcronyms, acronyms) + trailing
         if new_text != text:
             view.replace(edit, region, new_text)
+
+
+class ConvertToBetterTitleCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        run_on_selections(self.view, edit, to_better_title)
 
 
 class ToggleSnakeCamelPascalCommand(sublime_plugin.TextCommand):

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@ Case Conversion is a plugin for Sublime Text. It converts the current word/token
 camel, snake, screaming snake, dot, dash (hyphen), forward slash `/`, backslash `\` cases, and separated words.
 
 ## Keybindings
+- To Better Title Case:  "ctrl+alt+c", "ctrl+alt+t"
 - To snake_case:  "ctrl+alt+c", "ctrl+alt+s"
 - To SCREAMING_SNAKE_CASE:  "ctrl+alt+c", "ctrl+alt+shift+s"
 - To camelCase: "ctrl+alt+c", "ctrl+alt+c"
@@ -29,6 +30,7 @@ Clone this repository in to the Sublime Text "Packages" directory, which is loca
 - Curtis Gibby
 - Matt Morrison
 - Gavin Higham
+- Josh Dutterer
 
 ## License
 Copyright (C) 2012-2015 Davis Clark


### PR DESCRIPTION
`"committed_datetime:{}".format(committed_datetime)` into
`"Committed Datetime:{}".format(committed_datetime)` instead of
`"Committed_datetime:{}".format(committed_datetime)`